### PR TITLE
Bug Fix: VaultTestBase needs to be derived from ClientTestBase instead of unittest.TestCase

### DIFF
--- a/deuceclient/tests/__init__.py
+++ b/deuceclient/tests/__init__.py
@@ -274,7 +274,7 @@ class ClientTestBase(TestCase):
         return self.vault.vault_id
 
 
-class VaultTestBase(TestCase):
+class VaultTestBase(ClientTestBase):
 
     def setUp(self):
         super(VaultTestBase, self).setUp()

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = deuce-client
-version = 0.1-beta5
+version = 0.1-beta6
 summary = Client for Deuce De-Duplication-As-A-Service
 description-file = README.rst
 author = Rackspace


### PR DESCRIPTION
VaultTestBase is needed by downstream projects (f.e Deuce-Valere) for testing; however, functionality is also required that is in ClientTestBase. It is therefore best to derive VaultTestBase from ClientTestBase instead of unittest.TestCase to take advantage of that extra functionality.

Note: There still may be some redundant code in tests here; we'll take care of that later.