### PR TITLE
Bugfix sizing

### DIFF
--- a/deuceclient/api/block.py
+++ b/deuceclient/api/block.py
@@ -73,7 +73,7 @@ class Block(object):
                 'count': self.ref_count,
                 'modified': self.ref_modified
             },
-            'block_size': self.block_size,
+            'block_size': self.__properties['block_size'],
             'block_orphaned': self.block_orphaned,
             'block_type': self.block_type
         }
@@ -147,16 +147,14 @@ class Block(object):
 
     def __len__(self):
         if self.data is None:
-            return 0
+            if self.__properties['block_size'] is None:
+                return 0
+            else:
+                return self.__properties['block_size']
         else:
             return len(self.data)
 
-    @property
-    def block_size(self):
-        return self.__properties['block_size']
-
-    @block_size.setter
-    def block_size(self, value):
+    def set_block_size(self, value):
         self.__properties['block_size'] = value
 
     @property

--- a/deuceclient/client/deuce.py
+++ b/deuceclient/client/deuce.py
@@ -98,19 +98,36 @@ class DeuceClient(Command):
         return self.authenticator.AuthTenantId
 
     @validate(project=ProjectInstanceRule, marker=VaultIdRuleNoneOkay)
-    def ListVaults(self, project, marker=None):
+    def ListVaults(self, project, marker=None, limit=None):
         """List vaults for the user
+        :param marker: vaultid within the list to start at
+        :param limit: the maximum number of entries to retrieve
         :returns: deuceclient.api.Projects instance containing the vaults
         :raises: RuntimeError on failure
         """
-        path = api_v1.get_vault_base_path()
+        url = api_v1.get_vault_base_path()
 
-        if marker is not None:
-            self.ReInit(self.sslenabled,
-                        '{0:}?marker={1:}'.format(path, marker))
+        query_args = {}
+
+        if marker and limit:
+            query_args = {
+                'marker': marker,
+                'limit': limit,
+            }
+
+        elif marker:
+            query_args = {
+                'marker': marker
+            }
+        elif limit:
+            query_args = {
+                'limit': limit
+            }
         else:
-            self.ReInit(self.sslenabled, path)
+            pass
 
+        ret_url = set_qs_on_url(url, query_args)
+        self.ReInit(self.sslenabled, ret_url)
         self.__update_headers()
         self.__log_request_data(fn='List Vaults')
         res = requests.get(self.Uri, headers=self.Headers)
@@ -311,7 +328,6 @@ class DeuceClient(Command):
             pass
 
         ret_url = set_qs_on_url(url, query_args)
-
         self.ReInit(self.sslenabled, ret_url)
         self.__update_headers()
         self.__log_request_data(fn='Get Block List')
@@ -525,19 +541,37 @@ class DeuceClient(Command):
                 'Error ({0:}): {1:}'.format(res.status_code, res.text))
 
     @validate(vault=VaultInstanceRule, marker=FileIdRuleNoneOkay)
-    def ListFiles(self, vault, marker=None):
+    def ListFiles(self, vault, marker=None, limit=None):
         """List files in the Vault
 
         :param vault: vault to list the files from
+        :param marker: fileid within the list to start at
+        :param limit: the maximum number of entries to retrieve
         :returns: a list of file ids in the vault
         """
         url = api_v1.get_files_path(vault.vault_id)
-        if marker is not None:
-            self.ReInit(self.sslenabled,
-                        '{0:}?marker={1:}'.format(url, marker))
-        else:
-            self.ReInit(self.sslenabled, url)
 
+        query_args = {}
+
+        if marker and limit:
+            query_args = {
+                'marker': marker,
+                'limit': limit,
+            }
+
+        elif marker:
+            query_args = {
+                'marker': marker
+            }
+        elif limit:
+            query_args = {
+                'limit': limit
+            }
+        else:
+            pass
+
+        ret_url = set_qs_on_url(url, query_args)
+        self.ReInit(self.sslenabled, ret_url)
         self.__update_headers()
         self.__log_request_data(fn='List Files')
         res = requests.get(self.Uri, headers=self.Headers)
@@ -940,7 +974,6 @@ class DeuceClient(Command):
             pass
 
         ret_url = set_qs_on_url(url, query_args)
-
         self.ReInit(self.sslenabled, ret_url)
         self.__update_headers()
         self.__log_request_data(fn='Get Block Storage List')

--- a/deuceclient/client/deuce.py
+++ b/deuceclient/client/deuce.py
@@ -383,8 +383,8 @@ class DeuceClient(Command):
             block.ref_count = int(res.headers['X-Block-Reference-Count'])\
                 if res.headers['X-Block-Reference-Count'] else 0
 
-            block.block_size = int(res.headers['X-Block-Size'])\
-                if res.headers['X-Block-Size'] else 0
+            block.set_block_size(int(res.headers['X-Block-Size']
+                if res.headers['X-Block-Size'] else 0))
 
             block.storage_id = None if res.headers['X-Storage-ID'] == \
                 'None' else res.headers['X-Storage-ID']
@@ -1039,8 +1039,8 @@ class DeuceClient(Command):
             block.block_id = None if res.headers['X-Block-ID'] == \
                 'None' else res.headers['X-Block-ID']
 
-            block.block_size = int(res.headers['X-Block-Size'])\
-                if res.headers['X-Block-Size'] else 0
+            block.set_block_size(int(res.headers['X-Block-Size'])
+                if res.headers['X-Block-Size'] else 0)
 
             block.block_orphaned = \
                 json.loads(res.headers['X-Block-Orphaned'].lower())

--- a/deuceclient/tests/__init__.py
+++ b/deuceclient/tests/__init__.py
@@ -298,7 +298,7 @@ class VaultTestBase(ClientTestBase):
             self.assertEqual(a.storage_id, b.storage_id)
         self.assertEqual(a.ref_count, b.ref_count)
         self.assertEqual(a.ref_modified, b.ref_modified)
-        self.assertEqual(a.block_size, b.block_size)
+        self.assertEqual(len(a), len(b))
         self.assertEqual(a.block_orphaned, b.block_orphaned)
         self.assertEqual(a.block_type, b.block_type)
 

--- a/deuceclient/tests/test_api_block.py
+++ b/deuceclient/tests/test_api_block.py
@@ -309,17 +309,16 @@ class BlockTest(TestCase):
         block = api.Block(self.project_id,
                         self.vault_id,
                         self.block[0],
+                        data=None,
                         block_size=block_size)
 
-        self.assertIsNotNone(block.block_size)
-        self.assertEqual(block.block_size,
-                         block_size)
+        self.assertEqual(block_size,
+                         len(block))
 
-        block.block_size = 300
+        block.set_block_size(300)
 
-        self.assertIsNotNone(block.block_size)
         self.assertNotEqual(block_size,
-                            block.ref_modified)
+                            len(block))
 
     def test_modify_block_orphaned(self):
         block_orphaned = False

--- a/deuceclient/tests/test_client_deuce_block.py
+++ b/deuceclient/tests/test_client_deuce_block.py
@@ -493,5 +493,5 @@ class ClientDeuceBlockTests(ClientTestBase):
         self.assertEqual(block.ref_modified, check_data['ref-modified'])
         self.assertEqual(block.storage_id, check_data['storage-id'])
         self.assertEqual(block.block_id, block_id)
-        self.assertEqual(block.block_size, block_size)
+        self.assertEqual(len(block), block_size)
         self.assertFalse(block.block_orphaned)

--- a/deuceclient/tests/test_client_deuce_file_files_get.py
+++ b/deuceclient/tests/test_client_deuce_file_files_get.py
@@ -52,6 +52,36 @@ class ClientDeuceFileGetFilesTests(ClientTestBase):
         self.assertEqual(file_list, data)
         self.assertIsNone(self.vault.files.marker)
 
+    def test_file_get_with_limit(self):
+
+        data = [create_file() for _ in range(10)]
+
+        httpretty.register_uri(httpretty.GET,
+                               get_files_url(self.apihost,
+                                             self.vault.vault_id),
+                               body=json.dumps(data),
+                               status=200)
+
+        file_list = self.client.ListFiles(self.vault, limit=10)
+        self.assertEqual(file_list, data)
+        self.assertIsNone(self.vault.files.marker)
+
+    def test_file_get_with_marker_and_limit(self):
+
+        data = [create_file() for _ in range(10)]
+
+        httpretty.register_uri(httpretty.GET,
+                               get_files_url(self.apihost,
+                                             self.vault.vault_id),
+                               body=json.dumps(data),
+                               status=200)
+
+        file_list = self.client.ListFiles(self.vault,
+                                          marker=data[0],
+                                          limit=10)
+        self.assertEqual(file_list, data)
+        self.assertIsNone(self.vault.files.marker)
+
     def test_file_get_with_marker_more_data(self):
 
         data = [create_file() for _ in range(10)]

--- a/deuceclient/tests/test_client_deuce_storage_block.py
+++ b/deuceclient/tests/test_client_deuce_storage_block.py
@@ -229,7 +229,7 @@ class ClientDeuceStorageBlockTests(ClientTestBase):
         self.assertEqual(block.ref_modified, check_data['ref-modified'])
         self.assertEqual(block.storage_id, storage_blockid)
         self.assertEqual(block.block_id, blockid)
-        self.assertEqual(block.block_size, check_data['block-size'])
+        self.assertEqual(len(block), check_data['block-size'])
         self.assertTrue(block.block_orphaned)
 
     @httpretty.activate

--- a/deuceclient/tests/test_client_deuce_vault.py
+++ b/deuceclient/tests/test_client_deuce_vault.py
@@ -109,6 +109,30 @@ class ClientDeuceVaultTests(ClientTestBase):
             self.assertIn(vault_name, vault_list.keys())
 
     @httpretty.activate
+    def test_list_vault_success_with_limit_no_marker(self):
+        vault_list = {
+            vault_name: {'url': get_vault_url(self.apihost,
+                                              vault_name)} for vault_name in [
+                'vault_{0:}'.format(x) for x in range(10)]
+        }
+        httpretty.register_uri(httpretty.GET,
+                               get_vaults_url(
+                                   self.apihost),
+                               content_type='application/json',
+                               body=json.dumps(vault_list),
+                               status=200)
+        self.project['vault_0'] = api_vault.Vault(self.project.project_id,
+                                                  'vault_0')
+
+        self.assertTrue(self.client.ListVaults(self.project, limit=10))
+
+        for vault_name in vault_list.keys():
+            self.assertIn(vault_name, self.project)
+
+        for vault_name in self.project:
+            self.assertIn(vault_name, vault_list.keys())
+
+    @httpretty.activate
     def test_list_vault_success_with_marker_no_batch(self):
         vault_list = {
             vault_name: {'url': get_vault_url(self.apihost,
@@ -123,6 +147,35 @@ class ClientDeuceVaultTests(ClientTestBase):
                                status=200)
 
         self.assertTrue(self.client.ListVaults(self.project, 'vault_0'))
+
+        for vault_name in vault_list.keys():
+            self.assertIn(vault_name, self.project)
+
+        for vault_name in self.project:
+            self.assertIn(vault_name, vault_list.keys())
+
+    @httpretty.activate
+    def test_list_vault_success_with_marker_and_limit(self):
+        vault_list = {
+            vault_name: {'url': get_vault_url(self.apihost,
+                                              vault_name)} for vault_name in [
+                'vault_{0:}'.format(x) for x in range(10)]
+        }
+        next_batch = '{0}?marker=vault_11&limit=10'.format(
+            get_vault_base_path())
+        httpretty.register_uri(httpretty.GET,
+                               get_vaults_url(
+                                   self.apihost),
+                               content_type='application/json',
+                               adding_headers={
+                                   'x-next-batch': next_batch
+                               },
+                               body=json.dumps(vault_list),
+                               status=200)
+
+        self.assertTrue(self.client.ListVaults(self.project,
+                                               marker='vault_0',
+                                               limit=10))
 
         for vault_name in vault_list.keys():
             self.assertIn(vault_name, self.project)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = deuce-client
-version = 0.1-beta6
+version = 0.1-beta7
 summary = Client for Deuce De-Duplication-As-A-Service
 description-file = README.rst
 author = Rackspace


### PR DESCRIPTION
Previously we had two methods of determining block length: len(block), block.block_size this was problematic namely b/c block.block_size might return None.
- Updated to remove the block.block_size property and integrated it into len(block)
  - Refactored the block.block_size setter to a normal explicit function call to continue supporting use case where we do not have data but know the block size (f.e HEAD'ing a block)
  - Having the actual block data will override the value set using the block.set_block_size() call.

DEPENDS: PR #53 