### PR TITLE
Enhancement: Detect Missing Block error when downloading a block from deuce

### DIFF
--- a/deuceclient/client/deuce.py
+++ b/deuceclient/client/deuce.py
@@ -535,6 +535,11 @@ class DeuceClient(Command):
         if res.status_code == 200:
             block.data = res.content
             return True
+        elif res.status_code == 410:
+            raise errors.MissingBlockError(
+                'The Storage Block associated with Metadata Block {0:} '
+                'is missing from storage. Re-uploading the associated '
+                'data will restore access to any files using the block.')
         else:
             raise RuntimeError(
                 'Failed to get Block Content for Block Id . '

--- a/deuceclient/tests/test_client_deuce_block.py
+++ b/deuceclient/tests/test_client_deuce_block.py
@@ -427,6 +427,23 @@ class ClientDeuceBlockTests(ClientTestBase):
         with self.assertRaises(RuntimeError) as deletion_error:
             self.client.DownloadBlock(self.vault, block)
 
+    def test_block_download_missing(self):
+        block_id, block_data, block_size = create_block()
+        block = api.Block(project_id=self.vault.project_id,
+                          vault_id=self.vault.vault_id,
+                          block_id=block_id)
+
+        httpretty.register_uri(httpretty.GET,
+                               get_block_url(self.apihost,
+                                             self.vault.vault_id,
+                                             block.block_id),
+                               content_type='text/plain',
+                               body='mocking error',
+                               status=410)
+
+        with self.assertRaises(errors.MissingBlockError):
+            self.client.DownloadBlock(self.vault, block)
+
     def test_block_head_non_existent(self):
         block_id, block_data, block_size = create_block()
         block = api.Block(project_id=self.vault.project_id,

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = deuce-client
-version = 0.1-beta7
+version = 0.1-beta8
 summary = Client for Deuce De-Duplication-As-A-Service
 description-file = README.rst
 author = Rackspace


### PR DESCRIPTION
Deuce has a PR (https://github.com/rackerlabs/deuce/pull/245) for making HEAD and GET (download) work consistently with each other so they both return 404/410/(200/204) errors. This updates Deuce Client to match by adding the 410 check to the DownloadBlock (GET) functionality.