### PR TITLE
Enhancement: Update to reflect that we are doing releases to pypi

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -34,5 +34,5 @@ Deuce Client uses Python 3.3+ and can be installed into a Python 3.3+ environmen
 
 .. code-block:: bash
 
-	# pip install -e git+github.com:rackerlabs/deuce-client.git#egg=master
+	# pip install deuce-client
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = deuce-client
-version = 0.1-beta8
+version = 0.1-beta9
 summary = Client for Deuce De-Duplication-As-A-Service
 description-file = README.rst
 author = Rackspace


### PR DESCRIPTION
Noticed our README was still referencing install via pip+git. Updated to reflect pip+pypi installation.