### PR TITLE
Enhancement file assignment efficiency

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -34,5 +34,5 @@ Deuce Client uses Python 3.3+ and can be installed into a Python 3.3+ environmen
 
 .. code-block:: bash
 
-	# pip install -e git+github.com:rackerlabs/deuce-client.git#egg=master
+	# pip install deuce-client
 

--- a/deuceclient/client/deuce.py
+++ b/deuceclient/client/deuce.py
@@ -459,9 +459,14 @@ class DeuceClient(Command):
         self.__log_request_data(fn='Upload Multiple Blocks - msgpack')
         res = requests.post(self.Uri, headers=headers, data=body)
         self.__log_response_data(res,
-                                 jsondata=False,
+                                 jsondata=True,
                                  fn='Upload Multiple Blocks - msgpack')
-        if res.status_code == 201:
+        if res.status_code == 200:
+            for block_id, storage_block_id in res.json().items():
+                self.log.info('Vault {0}: Block {1} maps to storage block {2}'
+                              .format(vault.vault_id,
+                                      block_id,
+                                      storage_block_id))
             return True
         else:
             raise RuntimeError(

--- a/deuceclient/client/deuce.py
+++ b/deuceclient/client/deuce.py
@@ -814,8 +814,8 @@ class DeuceClient(Command):
         self.__log_response_data(res, jsondata=True,
                                  fn='Assign Blocks To File')
         if res.status_code == 200:
-            block_list_to_upload = [block_id
-                                    for block_id in res.json()]
+            block_list_to_upload = {block_id
+                                    for block_id in res.json()}
             return block_list_to_upload
         else:
             raise RuntimeError(

--- a/deuceclient/tests/test_client_deuce_block.py
+++ b/deuceclient/tests/test_client_deuce_block.py
@@ -143,6 +143,7 @@ class ClientDeuceBlockTests(ClientTestBase):
 
     def test_blocks_upload(self):
         blocks = []
+        response_data = {}
         for block_id, blockdata, block_size in [create_block()
                                                 for _ in range(5)]:
             blocks.append(block_id)
@@ -151,11 +152,13 @@ class ClientDeuceBlockTests(ClientTestBase):
                                 block_id=block_id,
                                 data=blockdata)
             self.vault.blocks[block_id] = a_block
+            response_data[block_id] = create_storage_block(block_id)
 
         httpretty.register_uri(httpretty.POST,
                                get_blocks_url(self.apihost,
                                               self.vault.vault_id),
-                               status=201)
+                               status=200,
+                               body=json.dumps(response_data))
 
         self.assertTrue(self.client.UploadBlocks(self.vault, blocks))
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = deuce-client
-version = 0.1-beta8
+version = 0.1-beta9
 summary = Client for Deuce De-Duplication-As-A-Service
 description-file = README.rst
 author = Rackspace


### PR DESCRIPTION
Ensure file assignments only try to upload blocks from a list of unique blocks by converting the response to a set
- added test to verify

DEPENDS: PR #57 